### PR TITLE
Fix UI startup crash and Multi-GPU row layout

### DIFF
--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -476,11 +476,6 @@ class TrainUI(ctk.CTk):
                          tooltip="Start saving automatically after this interval has elapsed")
         components.entry(frame, 5, 1, self.ui_state, "save_skip_first", width=50, sticky="nw")
 
-        # save filename prefix
-        components.label(frame, 6, 0, "Save Filename Prefix",
-                         tooltip="The prefix for filenames used when saving the model during training")
-        components.entry(frame, 6, 1, self.ui_state, "save_filename_prefix")
-
         frame.pack(fill="both", expand=1)
         return frame
 

--- a/modules/ui/TrainUI.py
+++ b/modules/ui/TrainUI.py
@@ -319,9 +319,9 @@ class TrainUI(ctk.CTk):
                          tooltip="Enable multi-GPU training")
         components.switch(frame, 12, 1, self.ui_state, "multi_gpu")
 
-        components.label(frame, 13, 2, "Device Indexes",
+        components.label(frame, 12, 2, "Device Indexes",
                          tooltip="Multi-GPU: A comma-separated list of device indexes. If empty, all your GPUs are used. With a list such as \"0,1,3,4\" you can omit a GPU, for example an on-board graphics GPU.")
-        components.entry(frame, 13, 3, self.ui_state, "device_indexes")
+        components.entry(frame, 12, 3, self.ui_state, "device_indexes")
 
         components.label(frame, 14, 0, "Gradient Reduce Precision",
                          tooltip="WEIGHT_DTYPE: Reduce gradients between GPUs in your weight data type; can be imprecise, but more efficient than float32\n"


### PR DESCRIPTION
## Summary
- Fixes a startup crash: `KeyError: 'save_filename_prefix'` in `modules/ui/TrainUI.py` (`create_backup_tab`). A merge from master reintroduced a "Save Filename Prefix" row referencing `save_filename_prefix`, a field already removed by the "Split model output destination" work on this branch (replaced by `run_name` / `run_name_mode` / `final_output_dir`). Removed the stale row.
- Fixes the "Device Indexes" row in the General tab: a previous merge left it on its own row (13, cols 2-3) while "Multi-GPU" stayed on row 12, leaving mismatched empty cells in both rows. Restored pairing them on the same row (12), matching upstream.

Drafted by Claude